### PR TITLE
expose copier as a runnable attribute of flake

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -15,6 +15,9 @@ in
   ];
 
   perSystem = { system, pkgs, ... }: {
+    packages = {
+      copier = pkgs.copier;
+    };
 
     devenv.shells.default = let
       kustomize = pkgs.kustomize.overrideAttrs (prevAttrs: {


### PR DESCRIPTION
i.e. `nix run github:LCOGT/devenv-k8s/v1#copier`