### PR TITLE
fix gcr.io/kpt-fn image refs

### DIFF
--- a/local-cluster/dash/deploy-caddy/Kptfile
+++ b/local-cluster/dash/deploy-caddy/Kptfile
@@ -20,6 +20,6 @@ upstreamLock:
     commit: c58213d7a52130c977fdff0a51f4bd4fb5ca73a3
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-replacements:v0.1.1
+    - image: ghcr.io/kptdev/krm-functions-catalog/apply-replacements:v0.1.1
       configPath: ./fn-replacements.yaml
       name: apply-replacements

--- a/local-cluster/dash/svc-caddy/Kptfile
+++ b/local-cluster/dash/svc-caddy/Kptfile
@@ -20,6 +20,6 @@ upstreamLock:
     commit: c58213d7a52130c977fdff0a51f4bd4fb5ca73a3
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-replacements:v0.1.1
+    - image: ghcr.io/kptdev/krm-functions-catalog/apply-replacements:v0.1.1
       configPath: ./fn-replacements.yaml
       name: apply-replacements

--- a/local-cluster/ingress-nginx/cronjob-update-local-lco-earth-cert/Kptfile
+++ b/local-cluster/ingress-nginx/cronjob-update-local-lco-earth-cert/Kptfile
@@ -20,6 +20,6 @@ upstreamLock:
     commit: 9f6e44ad68465ed19e016dc07da7872759c22a0c
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-replacements:v0.1.1
+    - image: ghcr.io/kptdev/krm-functions-catalog/apply-replacements:v0.1.1
       configPath: ./fn-replacements.yaml
       name: apply-replacements

--- a/local-cluster/ingress-nginx/helm/Kptfile
+++ b/local-cluster/ingress-nginx/helm/Kptfile
@@ -20,7 +20,7 @@ upstreamLock:
     commit: c58213d7a52130c977fdff0a51f4bd4fb5ca73a3
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/starlark:v0.5.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/starlark:v0.5.0
       configMap:
         source: |-
           output = "rendered.yaml"
@@ -34,10 +34,10 @@ pipeline:
 
           ctx.resource_list["items"] = new
       name: reset-rendered
-    - image: gcr.io/kpt-fn/render-helm-chart:v0.2.2
+    - image: ghcr.io/kptdev/krm-functions-catalog/render-helm-chart:v0.2.2
       configPath: ./charts.yaml
       name: render-helm-chart
-    - image: gcr.io/kpt-fn/starlark:v0.5.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/starlark:v0.5.0
       configMap:
         source: |-
           output = "rendered.yaml"


### PR DESCRIPTION
Updates:

### Regex[pattern=image:\s+(gcr\.io\/kpt-fn\/).+,file=**/Kptfile]
Update **/Kptfile
Updating file(s) `**/Kptfile` using pattern `image:\s+(gcr\.io\/kpt-fn\/).+`

### Regex[pattern=image:\s+(gcr\.io\/kpt-fn\/).+,file=**/*.yaml]
Update **/*.yaml
Updating file(s) `**/*.yaml` using pattern `image:\s+(gcr\.io\/kpt-fn\/).+`